### PR TITLE
Keyv stale cache

### DIFF
--- a/config/server.ts
+++ b/config/server.ts
@@ -7,7 +7,8 @@ const projectRootFolder = process.cwd();
 
 const isProd = process.env.NODE_ENV === 'production';
 
-const dbSuffix = isProd ? 'prod' : 'dev';
+// const dbSuffix = isProd ? 'prod' : 'dev';
+const dbSuffix = 'dev';
 const databaseFileName = `hn-new-jobs-database-${dbSuffix}.sqlite3`;
 
 export const SERVER_CONFIG = {

--- a/constants/cache.ts
+++ b/constants/cache.ts
@@ -2,4 +2,5 @@ export const CACHE_KEYS_DATABASE = {
   getNewOldCompaniesCountForAllMonthsCacheKey: 'getNewOldCompaniesCountForAllMonthsCacheKey',
   getStatisticsCacheKey: 'getStatisticsCacheKey',
   getNewOldCompaniesForMonthCacheKey: 'getNewOldCompaniesForMonthCacheKey',
+  getUpdatedAtCacheKey: 'getUpdatedAtCacheKey',
 } as const;

--- a/constants/cache.ts
+++ b/constants/cache.ts
@@ -2,4 +2,4 @@ export const CACHE_KEYS_DATABASE = {
   getNewOldCompaniesCountForAllMonthsCacheKey: 'getNewOldCompaniesCountForAllMonthsCacheKey',
   getStatisticsCacheKey: 'getStatisticsCacheKey',
   getNewOldCompaniesForMonthCacheKey: 'getNewOldCompaniesForMonthCacheKey',
-};
+} as const;

--- a/constants/scripts.ts
+++ b/constants/scripts.ts
@@ -3,4 +3,5 @@ export const SCRIPTS = {
   parseOld: 'old',
   parseOldMany: 'old-many',
   trimOld: 'trim-old',
+  trimNew: 'trim-new',
 } as const;

--- a/docs/working-notes/notes4.md
+++ b/docs/working-notes/notes4.md
@@ -35,3 +35,6 @@ if (cachedResult) return cachedResult;
 // set() Stores a Promise
   const dbResult = func(...args);
   await getCacheDatabase().set(key, dbResult);
+NIJE ISTI PROCESS u scheduler script, cli script, i u next.js page
+event?
+get number of months from db, check in next.js page and cache.clear() // to

--- a/docs/working-notes/notes4.md
+++ b/docs/working-notes/notes4.md
@@ -21,3 +21,17 @@ mozda samo portainer container recreate fails
 N new ads since yesterday, both debugging and ui, compare last month updatedAt // dobar feature
 deleteLastNMonths to debug updating
 remove plausible proxy for country, open issue and ask
+-----------------
+first newer month, check db too, not latest
+await getCacheDatabase().clear(); simply FAILS
+after clear() doesnt work
+----
+cacheDatabaseWrapper() must accept keyv as arg, pass getCacheDatabase() every time
+doesnt mutate
+always has data from memory, get() has memory
+const cachedResult = await getCacheDatabase().get<T>(key);
+console.log('key', key, 'cachedResult', cachedResult);
+if (cachedResult) return cachedResult;
+// set() Stores a Promise
+  const dbResult = func(...args);
+  await getCacheDatabase().set(key, dbResult);

--- a/docs/working-notes/notes4.md
+++ b/docs/working-notes/notes4.md
@@ -36,5 +36,7 @@ if (cachedResult) return cachedResult;
   const dbResult = func(...args);
   await getCacheDatabase().set(key, dbResult);
 NIJE ISTI PROCESS u scheduler script, cli script, i u next.js page
+cache.clear() zove u drugoj aplikaciji - procesu iako je isti import // glavna POENTA
 event?
 get number of months from db, check in next.js page and cache.clear() // to
+compare cached number of months and db number of months

--- a/libs/datetime.ts
+++ b/libs/datetime.ts
@@ -11,6 +11,8 @@ import { format as formatTz, toZonedTime } from 'date-fns-tz';
 
 import { SERVER_CONFIG } from '@/config/server';
 
+export type DateUnion = Date | string | number;
+
 const { appTimeZone, appDateTimeFormat } = SERVER_CONFIG;
 
 export const DATETIME = {
@@ -36,10 +38,10 @@ export const convertMonthNameToDate = (monthString: string): Date =>
  * Format to 'dd/MM/yyyy HH:mm:ss' to Belgrade time zone.
  * @example 05/11/2024 14:30:01
  */
-export const humanFormat = (date: Date): string =>
+export const humanFormat = (date: DateUnion): string =>
   formatTz(date, appDateTimeFormat, { timeZone: appTimeZone });
 
-export const getAppTime = (dateTime: Date): Date => toZonedTime(dateTime, appTimeZone);
+export const getAppTime = (dateTime: DateUnion): Date => toZonedTime(dateTime, appTimeZone);
 
 export const getAppNow = (): Date => getAppTime(new Date());
 

--- a/libs/keyv.ts
+++ b/libs/keyv.ts
@@ -88,11 +88,15 @@ export const getOrComputeValue = async <T, A extends any[]>(
 ): Promise<T> => {
   if (!cacheDatabaseDisabled) {
     const cachedResult = await getCache();
+    console.log('cachedResult', (cachedResult as any)?.forMonth);
+
     if (cachedResult) return cachedResult;
   }
 
   const dbResult = computeValue(...args);
   await setCache(dbResult);
+
+  console.log('dbResult', (dbResult as any)?.forMonth);
 
   return dbResult;
 };

--- a/modules/database/delete.ts
+++ b/modules/database/delete.ts
@@ -1,4 +1,5 @@
 import { getDb } from '@/modules/database/schema';
+import { getAllMonths } from '@/modules/database/select/month';
 import { isValidMonthName } from '@/utils/validation';
 import { ALGOLIA } from '@/constants/algolia';
 
@@ -17,6 +18,21 @@ export const deleteMonthsAndCompaniesOlderThanMonth = (
 
   // Delete months and cascade to related companies
   const changes = getDb().prepare(`DELETE FROM month WHERE name < ?`).run(monthName).changes;
+
+  return changes;
+};
+
+/**
+ * Newer than (excluding) monthName. Delete last month by default.
+ * For debugging cache invalidation on new month.
+ */
+export const deleteMonthsAndCompaniesNewerThanMonth = (
+  monthName = getAllMonths()[1].name
+): number => {
+  if (!isValidMonthName(monthName))
+    throw new Error(`Invalid format, monthName: ${monthName}. Expected "YYYY-MM".`);
+
+  const changes = getDb().prepare(`DELETE FROM month WHERE name > ?`).run(monthName).changes;
 
   return changes;
 };

--- a/modules/database/select/company.ts
+++ b/modules/database/select/company.ts
@@ -1,8 +1,12 @@
 import { getDb } from '@/modules/database/schema';
 import { getMonthByName, getMonthPairByName } from '@/modules/database/select/month';
 import { convertCompanyRowType, withCommentsQuery } from '@/modules/database/select/utils';
+import { cacheDatabaseWrapper, getDynamicCacheKey } from '@/libs/keyv';
+import { CACHE_KEYS_DATABASE } from '@/constants/cache';
 
 import { CompanyWithCommentsAsStrings, MonthPair, NewOldCompanies } from '@/types/database';
+
+const { getNewOldCompaniesForMonthCacheKey } = CACHE_KEYS_DATABASE;
 
 /** Compare two specific months by name. */
 
@@ -89,3 +93,10 @@ export const getNewOldCompaniesForMonth = (monthName: string): NewOldCompanies =
 
   return newOldCompanies;
 };
+
+export const getNewOldCompaniesForMonthCached = (monthName: string) =>
+  cacheDatabaseWrapper(
+    getDynamicCacheKey(getNewOldCompaniesForMonthCacheKey, monthName),
+    getNewOldCompaniesForMonth,
+    monthName
+  );

--- a/modules/database/select/company.ts
+++ b/modules/database/select/company.ts
@@ -1,12 +1,8 @@
 import { getDb } from '@/modules/database/schema';
 import { getMonthByName, getMonthPairByName } from '@/modules/database/select/month';
 import { convertCompanyRowType, withCommentsQuery } from '@/modules/database/select/utils';
-import { cacheDatabaseWrapper, getDynamicCacheKey } from '@/libs/keyv';
-import { CACHE_KEYS_DATABASE } from '@/constants/cache';
 
 import { CompanyWithCommentsAsStrings, MonthPair, NewOldCompanies } from '@/types/database';
-
-const { getNewOldCompaniesForMonthCacheKey } = CACHE_KEYS_DATABASE;
 
 /** Compare two specific months by name. */
 
@@ -93,10 +89,3 @@ export const getNewOldCompaniesForMonth = (monthName: string): NewOldCompanies =
 
   return newOldCompanies;
 };
-
-export const getNewOldCompaniesForMonthCached = (monthName: string) =>
-  cacheDatabaseWrapper(
-    getDynamicCacheKey(getNewOldCompaniesForMonthCacheKey, monthName),
-    getNewOldCompaniesForMonth,
-    monthName
-  );

--- a/modules/database/select/is-updated.ts
+++ b/modules/database/select/is-updated.ts
@@ -1,0 +1,63 @@
+import { cacheDatabaseWrapper, getCacheDatabase } from '@/libs/keyv';
+import logger from '@/libs/winston';
+import { CACHE_KEYS_DATABASE } from '@/constants/cache';
+import { getAllMonths } from './month';
+
+import { DbMonth } from '@/types/database';
+
+const { getUpdatedAtCacheKey } = CACHE_KEYS_DATABASE;
+
+export const getUpdatedAt = (): string[] => getAllMonths().map((month) => month.updatedAt);
+
+export const getUpdatedAtCached = () => cacheDatabaseWrapper(getUpdatedAtCacheKey, getUpdatedAt);
+
+export const findUpdatedMonth = (
+  allMonths: DbMonth[],
+  updatedAtArray: string[]
+): DbMonth | undefined => {
+  const updatedAtSet = new Set(updatedAtArray);
+
+  const dbMonth = allMonths.find((month) => !updatedAtSet.has(month.updatedAt));
+  if (dbMonth) return dbMonth;
+
+  const allMonthsUpdatedAtSet = new Set(allMonths.map((month) => month.updatedAt));
+  const missingUpdatedAt = updatedAtArray.find(
+    (updatedAt) => !allMonthsUpdatedAtSet.has(updatedAt)
+  );
+  if (missingUpdatedAt) {
+    return {
+      name: 'missing-in-db',
+      threadId: 'missing-in-db',
+      createdAtOriginal: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date(missingUpdatedAt).toISOString(),
+    };
+  }
+
+  return undefined;
+};
+
+export const getUpdatedMonth = async (): Promise<DbMonth | undefined> => {
+  const allMonths = getAllMonths();
+  const updatedAtArrayCached = await getUpdatedAtCached();
+
+  const updatedMonth = findUpdatedMonth(allMonths, updatedAtArrayCached);
+
+  return updatedMonth;
+};
+
+/** This must run on every request, to detect change. */
+
+export const clearCacheIfDatabaseUpdated = async (): Promise<DbMonth | undefined> => {
+  const updatedMonth = await getUpdatedMonth();
+
+  if (updatedMonth) {
+    logger.info('Database changed, clearing cache, updatedMonth:', updatedMonth);
+    await getCacheDatabase().clear();
+
+    // populate cache again
+    await getUpdatedAtCached();
+  }
+
+  return updatedMonth;
+};

--- a/modules/database/select/line-chart.ts
+++ b/modules/database/select/line-chart.ts
@@ -1,10 +1,6 @@
 import { getDb } from '@/modules/database/schema';
-import { cacheDatabaseWrapper } from '@/libs/keyv';
-import { CACHE_KEYS_DATABASE } from '@/constants/cache';
 
 import { LineChartMultipleData } from '@/types/charts';
-
-const { getNewOldCompaniesCountForAllMonthsCacheKey: lineChartCacheKey } = CACHE_KEYS_DATABASE;
 
 export const getNewOldCompaniesCountForAllMonths = (): LineChartMultipleData[] => {
   const query = `
@@ -85,6 +81,3 @@ export const getNewOldCompaniesCountForAllMonths = (): LineChartMultipleData[] =
 
   return result;
 };
-
-export const getNewOldCompaniesCountForAllMonthsCached = () =>
-  cacheDatabaseWrapper(lineChartCacheKey, getNewOldCompaniesCountForAllMonths);

--- a/modules/database/select/line-chart.ts
+++ b/modules/database/select/line-chart.ts
@@ -1,6 +1,10 @@
 import { getDb } from '@/modules/database/schema';
+import { cacheDatabaseWrapper } from '@/libs/keyv';
+import { CACHE_KEYS_DATABASE } from '@/constants/cache';
 
 import { LineChartMultipleData } from '@/types/charts';
+
+const { getNewOldCompaniesCountForAllMonthsCacheKey } = CACHE_KEYS_DATABASE;
 
 export const getNewOldCompaniesCountForAllMonths = (): LineChartMultipleData[] => {
   const query = `
@@ -81,3 +85,9 @@ export const getNewOldCompaniesCountForAllMonths = (): LineChartMultipleData[] =
 
   return result;
 };
+
+export const getNewOldCompaniesCountForAllMonthsCached = () =>
+  cacheDatabaseWrapper(
+    getNewOldCompaniesCountForAllMonthsCacheKey,
+    getNewOldCompaniesCountForAllMonths
+  );

--- a/modules/database/select/statistics.ts
+++ b/modules/database/select/statistics.ts
@@ -1,7 +1,11 @@
 import { getDb } from '@/modules/database/schema';
 import { getFirstMonth, getLastMonth } from '@/modules/database/select/month';
+import { cacheDatabaseWrapper } from '@/libs/keyv';
+import { CACHE_KEYS_DATABASE } from '@/constants/cache';
 
 import { Statistics } from '@/types/database';
+
+const { getStatisticsCacheKey } = CACHE_KEYS_DATABASE;
 
 export const getStatistics = (): Statistics => {
   const counts = getDb()
@@ -24,3 +28,5 @@ export const getStatistics = (): Statistics => {
 
   return statistics;
 };
+
+export const getStatisticsCached = () => cacheDatabaseWrapper(getStatisticsCacheKey, getStatistics);

--- a/modules/database/select/statistics.ts
+++ b/modules/database/select/statistics.ts
@@ -1,11 +1,7 @@
 import { getDb } from '@/modules/database/schema';
 import { getFirstMonth, getLastMonth } from '@/modules/database/select/month';
-import { cacheDatabaseWrapper } from '@/libs/keyv';
-import { CACHE_KEYS_DATABASE } from '@/constants/cache';
 
 import { Statistics } from '@/types/database';
-
-const { getStatisticsCacheKey } = CACHE_KEYS_DATABASE;
 
 export const getStatistics = (): Statistics => {
   const counts = getDb()
@@ -28,5 +24,3 @@ export const getStatistics = (): Statistics => {
 
   return statistics;
 };
-
-export const getStatisticsCached = () => cacheDatabaseWrapper(getStatisticsCacheKey, getStatistics);

--- a/modules/database/select/utils.ts
+++ b/modules/database/select/utils.ts
@@ -55,13 +55,6 @@ export const withCommentsQuery = (
     `;
 
 export const convertCompanyRowType = (row: CompanyWithCommentsAsStrings): CompanyWithComments => ({
-  company: {
-    name: row.name,
-    commentId: row.commentId,
-    monthName: row.monthName,
-    createdAtOriginal: new Date(row.createdAtOriginal),
-    createdAt: new Date(row.createdAt),
-    updatedAt: new Date(row.updatedAt),
-  },
+  company: row,
   comments: JSON.parse(row.comments) as DbCompany[],
 });

--- a/modules/parser/calls.ts
+++ b/modules/parser/calls.ts
@@ -1,6 +1,7 @@
 import { parseNewMonth, parseNOldMonths, parseOldMonth } from '@/modules/parser/parse';
 import { getAppNow } from '@/libs/datetime';
 import { getCacheDatabase } from '@/libs/keyv';
+import { CACHE_KEYS_DATABASE } from '@/constants/cache';
 import { SERVER_CONFIG } from '@/config/server';
 
 import { ParserResponse } from '@/types/api';
@@ -28,7 +29,18 @@ export const callParseNewMonth = async (): Promise<ParserResponse> => {
     parserResults: [parserResult],
   };
 
+  const { getNewOldCompaniesCountForAllMonthsCacheKey } = CACHE_KEYS_DATABASE;
+  const newOldCompaniesForAllMonthsBefore = await getCacheDatabase().get(
+    getNewOldCompaniesCountForAllMonthsCacheKey
+  );
+  console.log('newOldCompaniesForAllMonthsBefore', newOldCompaniesForAllMonthsBefore?.length);
+
   await getCacheDatabase().clear();
+
+  const newOldCompaniesForAllMonthsAfter = await getCacheDatabase().get(
+    getNewOldCompaniesCountForAllMonthsCacheKey
+  );
+  console.log('newOldCompaniesForAllMonthsAfter', newOldCompaniesForAllMonthsAfter);
 
   return parserResponse;
 };

--- a/modules/parser/main.ts
+++ b/modules/parser/main.ts
@@ -1,8 +1,5 @@
 import { callParseNewMonth, callParseNOldMonths, callParseOldMonth } from '@/modules/parser/calls';
-import {
-  deleteMonthsAndCompaniesNewerThanMonth,
-  deleteMonthsAndCompaniesOlderThanMonth,
-} from '@/modules/database/delete';
+import { deleteMonthsAndCompaniesNewerThanMonth } from '@/modules/database/delete';
 import { getCacheDatabase } from '@/libs/keyv';
 import logger from '@/libs/winston';
 import { CACHE_KEYS_DATABASE } from '@/constants/cache';
@@ -20,7 +17,7 @@ const main = async (script: ScriptType) => {
   switch (script) {
     case SCRIPTS.parseNew: {
       const parserResponse: ParserResponse = await callParseNewMonth();
-      logger.info('main.ts parseNew script, parserResponse:', parserResponse);
+      logger.info('main.ts parseNew script, parserResponse:', { parserResponse });
       break;
     }
     case SCRIPTS.parseOld: {

--- a/modules/parser/main.ts
+++ b/modules/parser/main.ts
@@ -1,6 +1,11 @@
 import { callParseNewMonth, callParseNOldMonths, callParseOldMonth } from '@/modules/parser/calls';
-import { deleteMonthsAndCompaniesOlderThanMonth } from '@/modules/database/delete';
+import {
+  deleteMonthsAndCompaniesNewerThanMonth,
+  deleteMonthsAndCompaniesOlderThanMonth,
+} from '@/modules/database/delete';
+import { getCacheDatabase } from '@/libs/keyv';
 import logger from '@/libs/winston';
+import { CACHE_KEYS_DATABASE } from '@/constants/cache';
 import { SCRIPTS } from '@/constants/scripts';
 import { SERVER_CONFIG } from '@/config/server';
 import { getStatistics } from '../database/select/statistics';
@@ -30,12 +35,35 @@ const main = async (script: ScriptType) => {
       break;
     }
     case SCRIPTS.trimOld: {
+      // const statisticsBefore = getStatistics();
+      // const rowsCount = deleteMonthsAndCompaniesOlderThanMonth();
+      // const statisticsAfter = getStatistics();
+
+      // const context = { rowsCount, statisticsBefore, statisticsAfter };
+      // logger.info('main.ts script, deleted old rows:', context);
+
+      const { getNewOldCompaniesCountForAllMonthsCacheKey } = CACHE_KEYS_DATABASE;
+      const newOldCompaniesForAllMonthsBefore = await getCacheDatabase().get(
+        getNewOldCompaniesCountForAllMonthsCacheKey
+      );
+      console.log('newOldCompaniesForAllMonthsBefore', newOldCompaniesForAllMonthsBefore?.length);
+
+      await getCacheDatabase().clear();
+
+      const newOldCompaniesForAllMonthsAfter = await getCacheDatabase().get(
+        getNewOldCompaniesCountForAllMonthsCacheKey
+      );
+      console.log('newOldCompaniesForAllMonthsAfter', newOldCompaniesForAllMonthsAfter);
+
+      break;
+    }
+    case SCRIPTS.trimNew: {
       const statisticsBefore = getStatistics();
-      const rowsCount = deleteMonthsAndCompaniesOlderThanMonth();
+      const rowsCount = deleteMonthsAndCompaniesNewerThanMonth();
       const statisticsAfter = getStatistics();
 
       const context = { rowsCount, statisticsBefore, statisticsAfter };
-      logger.info('main.ts script, deleted rows:', context);
+      logger.info('main.ts script, deleted new rows:', context);
       break;
     }
   }

--- a/modules/parser/main.ts
+++ b/modules/parser/main.ts
@@ -1,8 +1,9 @@
 import { callParseNewMonth, callParseNOldMonths, callParseOldMonth } from '@/modules/parser/calls';
-import { deleteMonthsAndCompaniesNewerThanMonth } from '@/modules/database/delete';
-import { getCacheDatabase } from '@/libs/keyv';
+import {
+  deleteMonthsAndCompaniesNewerThanMonth,
+  deleteMonthsAndCompaniesOlderThanMonth,
+} from '@/modules/database/delete';
 import logger from '@/libs/winston';
-import { CACHE_KEYS_DATABASE } from '@/constants/cache';
 import { SCRIPTS } from '@/constants/scripts';
 import { SERVER_CONFIG } from '@/config/server';
 import { getStatistics } from '../database/select/statistics';
@@ -32,28 +33,16 @@ const main = async (script: ScriptType) => {
       break;
     }
     case SCRIPTS.trimOld: {
-      // const statisticsBefore = getStatistics();
-      // const rowsCount = deleteMonthsAndCompaniesOlderThanMonth();
-      // const statisticsAfter = getStatistics();
+      const statisticsBefore = getStatistics();
+      const rowsCount = deleteMonthsAndCompaniesOlderThanMonth();
+      const statisticsAfter = getStatistics();
 
-      // const context = { rowsCount, statisticsBefore, statisticsAfter };
-      // logger.info('main.ts script, deleted old rows:', context);
-
-      const { getNewOldCompaniesCountForAllMonthsCacheKey } = CACHE_KEYS_DATABASE;
-      const newOldCompaniesForAllMonthsBefore = await getCacheDatabase().get(
-        getNewOldCompaniesCountForAllMonthsCacheKey
-      );
-      console.log('newOldCompaniesForAllMonthsBefore', newOldCompaniesForAllMonthsBefore?.length);
-
-      await getCacheDatabase().clear();
-
-      const newOldCompaniesForAllMonthsAfter = await getCacheDatabase().get(
-        getNewOldCompaniesCountForAllMonthsCacheKey
-      );
-      console.log('newOldCompaniesForAllMonthsAfter', newOldCompaniesForAllMonthsAfter);
+      const context = { rowsCount, statisticsBefore, statisticsAfter };
+      logger.info('main.ts script, deleted old rows:', context);
 
       break;
     }
+    // for debugging cache.clear()
     case SCRIPTS.trimNew: {
       const statisticsBefore = getStatistics();
       const rowsCount = deleteMonthsAndCompaniesNewerThanMonth();

--- a/modules/parser/months.ts
+++ b/modules/parser/months.ts
@@ -1,7 +1,10 @@
 import { getAllMonths } from '@/modules/parser/algolia/threads';
 import { getFirstMonth, getLastMonth } from '@/modules/database/select/month';
 
-/** Always update latest month. */
+/**
+ * Parse first month newer than in the database, not only the latest.
+ * Always update the latest month.
+ */
 
 export const getNewMonthName = async (): Promise<string> => {
   const lastMonth = getLastMonth();

--- a/modules/parser/months.ts
+++ b/modules/parser/months.ts
@@ -1,15 +1,40 @@
 import { getAllMonths } from '@/modules/parser/algolia/threads';
-import { getFirstMonth } from '@/modules/database/select/month';
+import { getFirstMonth, getLastMonth } from '@/modules/database/select/month';
 
 /** Always update latest month. */
 
 export const getNewMonthName = async (): Promise<string> => {
+  const lastMonth = getLastMonth();
+
   const parsedMonths = await getAllMonths();
   if (!(parsedMonths.length > 0))
     throw new Error(`Invalid parsedMonths length: ${parsedMonths.length}`);
 
-  // overwrite
-  return parsedMonths[0];
+  let newMonthName: string;
+
+  // handle empty db
+  if (!lastMonth) {
+    // gets last thread on empty db
+    newMonthName = parsedMonths[0];
+    return newMonthName;
+  }
+
+  const index = parsedMonths.indexOf(lastMonth.name);
+  // index not found or out of bounds
+  if (!(index !== -1 && index < parsedMonths.length - 1))
+    throw new Error(
+      `IndexOf lastMonth.name: ${lastMonth.name} from database not found in parsedMonths.`
+    );
+
+  // redo last month
+  if (index === 0) {
+    newMonthName = parsedMonths[0];
+    return newMonthName;
+  }
+
+  // one month newer
+  newMonthName = parsedMonths[index - 1];
+  return newMonthName;
 };
 
 export const getOldMonthName = async (): Promise<string> => {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "hn:dev:old": "tsx modules/parser/main.ts old",
     "hn:dev:old-many": "tsx modules/parser/main.ts old-many",
     "hn:dev:trim-old": "tsx modules/parser/main.ts trim-old",
+    "hn:dev:trim-new": "tsx modules/parser/main.ts trim-new",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "preview": "next build && next start",

--- a/types/database.ts
+++ b/types/database.ts
@@ -8,26 +8,29 @@ import { ValueUnion } from '@/types/utils';
 export interface DbMonth {
   name: string;
   threadId: string;
-  createdAtOriginal: Date;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAtOriginal: string; // string in better-sqlite3, not Date
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface DbCompany {
   name: string;
   commentId: string;
   monthName: string;
-  createdAtOriginal: Date;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAtOriginal: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 /*-------------------------------- Insert ------------------------------*/
 
-export interface DbCompanyInsert
-  extends Pick<DbCompany, 'name' | 'commentId' | 'createdAtOriginal'> {}
+export interface DbCompanyInsert extends Pick<DbCompany, 'name' | 'commentId'> {
+  createdAtOriginal: Date;
+}
 
-export interface DbMonthInsert extends Pick<DbMonth, 'name' | 'threadId' | 'createdAtOriginal'> {}
+export interface DbMonthInsert extends Pick<DbMonth, 'name' | 'threadId'> {
+  createdAtOriginal: Date;
+}
 
 /*-------------------------- Select ------------------------*/
 


### PR DESCRIPTION
`get()` and `set()` must run on request time, not once in global scope.

The main problem was that `cache.clear()` was called from separate process. Solution: detect database change and call `cache.clear()` within Next.js app process on page request.